### PR TITLE
Make RoundCube serverName configurable

### DIFF
--- a/cas_authn/cas_authn.php
+++ b/cas_authn/cas_authn.php
@@ -376,7 +376,13 @@ class cas_authn extends rcube_plugin {
                 $delm = '&';
             }
         }
-        return $protocol . '://' . $_SERVER['SERVER_NAME'] . $port . $path . $parsed_params;
+        $cfg = rcmail::get_instance()->config->all();
+        if ( $cfg['cas_webmail_server_name'] ) {
+          $serverName = $cfg['cas_webmail_server_name'];
+        } else {
+          $serverName=$_SERVER['SERVER_NAME'];
+        }
+        return $protocol . '://' . $serverName . $port . $path . $parsed_params;
     }
 
     private function strleft($s1, $s2) {


### PR DESCRIPTION
On bigger setup the RoundCube setups are hidden behind reverse proxy. In such cases the roundcube server's 'SERVER_NAME' isn't the URL we want to provide to the CAS server.

This patch allows users to add a configuration value to set the server name of the roundcube server.
