### PR TITLE
Adding support for PT renew

### DIFF
--- a/cas_authn/config.inc.php.dist
+++ b/cas_authn/config.inc.php.dist
@@ -40,6 +40,9 @@ $rcmail_config['cas_smtp_name'] = 'name_of_imap_service';
 //    significantly reduces the number of requests made to the CAS server.
 $rcmail_config['cas_imap_caching'] = true;
 
+// Time (in seconds) before expiration of cached IMAP Proxy Ticket. After expiration the PT is renewed.
+$rcmail_config['cas_imap_pt_expiration_time'] = 300;
+
 // password for logging into the IMAP server. Will only be used if cas_proxy
 //     is set to false. The IMAP backend must accept this password for all
 //     authorized users.


### PR DESCRIPTION
Usefull to renew a PT after his timeout, must be synchronized with IMAP session timeout.
