### PR TITLE
Fix incorrect usage of phpCAS on PT renewal

### DIFF
--- a/cas_authn/cas_authn.php
+++ b/cas_authn/cas_authn.php
@@ -173,10 +173,9 @@ class cas_authn extends rcube_plugin {
             else {
                 // initialize CAS client
                 $this->cas_init();
-				// If PT expired we check the authentication to load all auth infos wich lays in session
-				if ($ptExpired) {
-					phpCAS::checkAuthentication();
-				}       
+
+                // Ensure the phpCAS client is up to date with session info before retrieving a new PT
+                phpCAS::checkAuthentication();
 
                 // if CAS session exists, use that.
                 // retrieve a new proxy ticket and store it in session


### PR DESCRIPTION
Using retrievePT without updating the phpCAS client from session info
will result in an incorrect call to the CAS server :

Error while retrieving new PT: PT retrieving failed
(code=`INVALID_REQUEST', message=`'pgt' and 'targetService' parameters are both
required')

This only happens in cases where the PT becomes invalid without
expiring, for instance if the credential cache does not manage multiple
credentials, or if it expires for any reason other than timing out.
This particular cas was not handled by the previous code.
