### PR TITLE
Added support of Dovecot's master user. Added option "cas_disable_for_domains".

### DIFF
--- a/cas_authn/cas_authn.php
+++ b/cas_authn/cas_authn.php
@@ -22,6 +22,7 @@
 class cas_authn extends rcube_plugin {
     
     private $cas_inited;
+    private $_cache_cfg = null;
     
     /**
      * Initialize plugin
@@ -46,8 +47,20 @@ class cas_authn extends rcube_plugin {
         $this->add_hook('template_object_loginform', array($this, 'add_cas_login_html'));
     }
 
+    /**
+     * Gets config and caches
+     *
+     * @return array configuration array
+     */
+    function getCfg() {
+        if (is_null($_cache_cfg)) {
+             $_cache_cfg = rcmail::get_instance()->config->all();
+        }
+        return $_cache_cfg;
+    }
+
     function isDisabled() {
-        $cfg = rcmail::get_instance()->config->all();
+        $cfg = $this->getCfg();
         if (is_array($cfg['cas_disable_for_domains'])) {
             foreach ($cfg['cas_disable_for_domains'] as $domain_pattern) {
                 if (preg_match($domain_pattern, $_SERVER['SERVER_NAME'])) {
@@ -122,7 +135,7 @@ class cas_authn extends rcube_plugin {
             $user = phpCAS::getUser();
             $pass = '';
             // retrieve credentials, either a Proxy Ticket or 'masteruser' password
-            $cfg = rcmail::get_instance()->config->all();
+            $cfg = $this->getCfg();
             if ($cfg['cas_proxy']) {
                 $_SESSION['cas_pt'][php_uname('n')] = phpCAS::retrievePT($cfg['cas_imap_name'], $err_code, $output);
                 $pass = $_SESSION['cas_pt'][php_uname('n')];
@@ -175,7 +188,7 @@ class cas_authn extends rcube_plugin {
      */
     function imap_connect($args) {
         // retrieve configuration
-        $cfg = rcmail::get_instance()->config->all();
+        $cfg = $this->getCfg();
         
         // RoundCube is acting as CAS proxy
         if ($cfg['cas_proxy']) {
@@ -237,7 +250,7 @@ class cas_authn extends rcube_plugin {
      */
     function smtp_connect($args) {
         // retrieve configuration
-        $cfg = rcmail::get_instance()->config->all();
+        $cfg = $this->getCfg();
         
         // RoundCube is acting as CAS proxy and performing SMTP authn
         if ($cfg['cas_proxy'] && $args['smtp_user'] && $args['smtp_pass']) {
@@ -267,7 +280,7 @@ class cas_authn extends rcube_plugin {
      */
     function sieverules_connect($args) {
         // retrieve configuration
-        $cfg = rcmail::get_instance()->config->all();
+        $cfg = $this->getCfg();
 
         // RoundCube is acting as CAS proxy
         if ($cfg['opt_cas_proxy']) {
@@ -293,7 +306,7 @@ class cas_authn extends rcube_plugin {
         $RCMAIL = rcmail::get_instance();
         $this->add_texts('localization');
         // retrieve configuration
-        $cfg = rcmail::get_instance()->config->all();
+        $cfg = $this->getCfg();
     
         // Force CAS authn?
 	if($cfg["cas_force"]) {
@@ -329,7 +342,7 @@ class cas_authn extends rcube_plugin {
 		session_destroy();
 	    }
 
-            $cfg = rcmail::get_instance()->config->all();
+            $cfg = $this->getCfg();
 
             // include phpCAS
             require_once('CAS.php');
@@ -420,7 +433,7 @@ class cas_authn extends rcube_plugin {
                 $delm = '&';
             }
         }
-        $cfg = rcmail::get_instance()->config->all();
+        $cfg = $this->getCfg();
         if ( $cfg['cas_webmail_server_name'] ) {
           $serverName = $cfg['cas_webmail_server_name'];
         } else {

--- a/cas_authn/cas_authn.php
+++ b/cas_authn/cas_authn.php
@@ -59,6 +59,11 @@ class cas_authn extends rcube_plugin {
         return $_cache_cfg;
     }
 
+    /**
+     * Determine if this plugin should be disable for current request
+     *
+     * @return bool true -- disabled; false -- enabled
+     */
     function isDisabled() {
         $cfg = $this->getCfg();
         if (is_array($cfg['cas_disable_for_domains'])) {
@@ -78,7 +83,7 @@ class cas_authn extends rcube_plugin {
      * these actions need to be handled.
      *
      * @param array $args arguments from rcmail
-* @return array modified arguments
+     * @return array modified arguments
      */
     function startup($args) {
         // intercept PGT callback action from CAS server

--- a/cas_authn/cas_authn.php
+++ b/cas_authn/cas_authn.php
@@ -312,9 +312,11 @@ class cas_authn extends rcube_plugin {
         $this->add_texts('localization');
         // retrieve configuration
         $cfg = $this->getCfg();
+
+        $this->cas_init();
     
         // Force CAS authn?
-	if($cfg["cas_force"]) {
+	if($cfg["cas_force"] && !phpCAS::checkAuthentication()) {
             global $OUTPUT;
             $OUTPUT->redirect(array('action' => 'caslogin'));
         }

--- a/cas_authn/cas_authn.php
+++ b/cas_authn/cas_authn.php
@@ -113,6 +113,15 @@ class cas_authn extends rcube_plugin {
             }
             else {
                 $pass = $cfg['cas_imap_password'];
+
+                if (!empty($cfg['cas_imap_masteruser'])) {
+                    if (!empty($cfg['username_domain'])) {
+                        $user .= '@'.rcube_utils::parse_host($cfg['username_domain']).'*'.$cfg['cas_imap_masteruser'];
+                        $cfg['username_domain'] = '';
+                    } else {
+                        $user .= '*'.$cfg['cas_imap_masteruser'];
+                    }
+                }
             }
    
             // Do Roundcube login actions

--- a/cas_authn/cas_authn.php
+++ b/cas_authn/cas_authn.php
@@ -33,6 +33,10 @@ class cas_authn extends rcube_plugin {
         
         // load plugin configuration
         $this->load_config();
+
+        if ($this->isDisabled()) {
+            return;
+        }
         
         // add application hooks
         $this->add_hook('startup', array($this, 'startup'));
@@ -40,6 +44,18 @@ class cas_authn extends rcube_plugin {
         $this->add_hook('smtp_connect', array($this, 'smtp_connect'));
         $this->add_hook('sieverules_connect', array($this, 'sieverules_connect'));
         $this->add_hook('template_object_loginform', array($this, 'add_cas_login_html'));
+    }
+
+    function isDisabled() {
+        $cfg = rcmail::get_instance()->config->all();
+        if (is_array($cfg['cas_disable_for_domains'])) {
+            foreach ($cfg['cas_disable_for_domains'] as $domain_pattern) {
+                if (preg_match($domain_pattern, $_SERVER['SERVER_NAME'])) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**

--- a/cas_authn/config.inc.php.dist
+++ b/cas_authn/config.inc.php.dist
@@ -48,6 +48,15 @@ $rcmail_config['cas_imap_pt_expiration_time'] = 300;
 //     authorized users.
 $rcmail_config['cas_imap_password'] = '';
 
+// Don't authenticate to IMAP using user's username. Use "username*masteruser" instead.
+//     If user's username is "user@example.com" and master's username is "master@example.com"
+//     then the plugin will authenticate using username "user@example.com*master@example.com".
+//     See "http://wiki2.dovecot.org/Authentication/MasterUsers" for more information.
+//     This option is ignored if "cas_proxy" is set to true.
+//
+//     To disable this option -- just comment it out.
+//$rcmail_config['cas_imap_masteruser'] = 'master@example.com';
+
 // CAS server host name.
 $rcmail_config['cas_hostname'] = 'address.of.cas.server';
 

--- a/cas_authn/config.inc.php.dist
+++ b/cas_authn/config.inc.php.dist
@@ -9,6 +9,10 @@
 //     the CAS login URL. This means nobody will ever see the RC login page.
 $rcmail_config['cas_force'] = false;
 
+// Disable this plugin for 'SERVER_NAME' that matches to a pattern from the
+//     array:
+$rcmail_config['cas_disable_for_domains'] = array("/nocas\.example\.com/", "/.*\.nocas\.example\.com/");
+
 // whether to act as a CAS proxy. If set to true, a proxy ticket will be
 //     retrieved from the CAS server to be used as password for logging into
 //     the IMAP server. This is the preferred method of authenticating


### PR DESCRIPTION
Master user support can to not work in some cases, but it's better than nothing.

Option "cas_disable_for_domains" just disables the plugin for domains specified by regexs.
